### PR TITLE
Fix some spelling and grammar typos in lang

### DIFF
--- a/loader-common/src/main/resources/assets/colossalchests/lang/en_us.json
+++ b/loader-common/src/main/resources/assets/colossalchests/lang/en_us.json
@@ -68,5 +68,5 @@
     "multiblock.colossalchests.error.unexpected": "Unexpected Colossal Chest structure error.",
     "multiblock.colossalchests.error.material": "Found a block of material %s at %s, while %s was expected.",
     "multiblock.colossalchests.error.upgrade": "Not enough items for upgrading this chest, you need %s cores, %s interfaces and %s walls of at least the material %s.",
-    "multiblock.colossalchests.error.upgradeLimit": "You can not transform this chest anymore."
+    "multiblock.colossalchests.error.upgradeLimit": "You can not transform this chest any further."
 }


### PR DESCRIPTION
The only grammar problem I found was in the final string. If you cannot transform it "anymore", it generally signals that there is a random reason why. But "any further" specifically refers to some limit about to exceed. The latter seems to fit better here.