### PR TITLE
Add performance benchmarking setup

### DIFF
--- a/.github/parse_benchmark_results.sh
+++ b/.github/parse_benchmark_results.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Parse benchmark results from game tests and convert to JSON format
+# for use with benchmark-action/github-action-benchmark
+
+set -e
+
+BENCH_FILE="benchmark_results.json"
+RESULTS_FILE="${PERFORMANCE_BENCHMARK_OUTPUT:-benchmark_results.txt}"
+
+echo "Parsing benchmark results..."
+
+if [ ! -f "$RESULTS_FILE" ]; then
+    echo "Benchmark results file not found at $RESULTS_FILE"
+    exit 1
+fi
+
+echo "[" > "$BENCH_FILE"
+
+FIRST=true
+while IFS= read -r line; do
+    if [ -z "$line" ]; then
+        continue
+    fi
+
+    # Parse the line: preset=<preset> size=<size> (avgOperationTime=<time> | bytesPerSlot=<bytes>)
+    preset=$(echo "$line" | sed -n 's/.*preset=\([^ ]*\).*/\1/p')
+    size=$(echo "$line" | sed -n 's/.*size=\([0-9]*\).*/\1/p')
+    operationTime=$(echo "$line" | sed -n 's/.*avgOperationTime=\([0-9.]*\).*/\1/p')
+    bytesPerSlot=$(echo "$line" | sed -n 's/.*bytesPerSlot=\([0-9]*\).*/\1/p')
+
+    if [ -z "$preset" ] || [ -z "$size" ]; then
+        continue
+    fi
+
+    if [ -n "$operationTime" ]; then
+        if [ "$FIRST" = true ]; then
+            FIRST=false
+        else
+            echo "," >> "$BENCH_FILE"
+        fi
+        cat >> "$BENCH_FILE" << EOF
+  {
+    "name": "CHEST LOAD: ${preset}_size_${size}",
+    "unit": "operation time (ms)",
+    "value": $operationTime
+  }
+EOF
+    fi
+
+    if [ -n "$bytesPerSlot" ]; then
+        if [ "$FIRST" = true ]; then
+            FIRST=false
+        else
+            echo "," >> "$BENCH_FILE"
+        fi
+        cat >> "$BENCH_FILE" << EOF
+  {
+    "name": "CHEST MEMORY: ${preset}_size_${size}",
+    "unit": "bytes per slot",
+    "value": $bytesPerSlot
+  }
+EOF
+    fi
+done < "$RESULTS_FILE"
+
+echo "" >> "$BENCH_FILE"
+echo "]" >> "$BENCH_FILE"
+
+echo "✓ Benchmark results parsed successfully:"
+echo ""
+cat "$BENCH_FILE"

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,65 @@
+name: "Performance"
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Benchmark
+    if: github.event.repository.fork != true && (startsWith(github.ref, 'refs/heads/master') || startsWith(github.ref, 'refs/heads/feature'))
+    runs-on: ubuntu-latest
+    env:
+      PERFORMANCE_BENCHMARK_OUTPUT: ${{ github.workspace }}/benchmark_results.txt
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: 'Setup Java'
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'microsoft'
+          java-version: 21
+      - name: 'Setup Gradle'
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: false
+      - name: 'Build'
+        run: ./gradlew build -x test --no-daemon
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Run performance benchmarks'
+        run: ./gradlew :loader-neoforge:runGameTestServer
+        env:
+          PERFORMANCE_BENCHMARK_ENABLED: 'true'
+        continue-on-error: true
+      - name: 'Parse benchmark results'
+        run: bash .github/parse_benchmark_results.sh
+      - name: Determine benchmarks total results target directory name
+        run: echo "BENCHMARK_DATA_DIR_PATH=CyclopsMC/ColossalChests/${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}/benchmarks" >> $GITHUB_ENV
+      - name: 'Store benchmark result'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Colossal Chests Benchmark
+          tool: customSmallerIsBetter
+          output-file-path: benchmark_results.json
+          github-token: ${{ secrets.PAT }}
+          auto-push: true
+          alert-threshold: '250%'
+          comment-always: true
+          comment-on-alert: true
+          alert-comment-cc-users: '@rubensworks'
+          summary-always: true
+          gh-repository: github.com/CyclopsMC/cyclops-performance-results
+          gh-pages-branch: master
+          benchmark-data-dir-path: ${{ env.BENCHMARK_DATA_DIR_PATH }}
+      - name: Prepare comment on commit with link to performance results
+        run: echo -e "Performance benchmarks succeeded! 🚀\n\n\[[Results](https://CyclopsMC.github.io/cyclops-performance-results/CyclopsMC/ColossalChests/${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}/benchmarks/)\]" > ./commit-comment-body.txt
+      - name: Comment on commit with link to performance results
+        uses: peter-evans/commit-comment@v4
+        with:
+          body-path: ./commit-comment-body.txt

--- a/PERFORMANCE_BENCHMARKING.md
+++ b/PERFORMANCE_BENCHMARKING.md
@@ -1,0 +1,102 @@
+# Performance Benchmarking Setup
+
+This document describes the performance benchmarking infrastructure for Colossal Chests.
+Performance results are tracked in https://github.com/CyclopsMC/cyclops-performance-results
+
+## Overview
+
+The performance benchmarking system consists of three main components:
+
+1. **GitHub Workflow** (`.github/workflows/performance.yml`)
+   - Executes on the same triggers as CI (push and pull_request)
+   - Runs the benchmark game tests on the NeoForge loader
+   - Uses `benchmark-action/github-action-benchmark` to track performance evolution
+
+2. **Game Tests** (`loader-common/src/main/java/org/cyclops/colossalchests/gametest/GameTestsPerformance.java`)
+   - Benchmarks the operations that scale with chest size
+   - Skipped unless `PERFORMANCE_BENCHMARK_ENABLED=true`, as they are much slower than regular game tests
+   - Appends results to the file pointed at by `PERFORMANCE_BENCHMARK_OUTPUT` (default: `logs/benchmark_results.txt`, relative to the run directory)
+
+3. **Result parsing** (`.github/parse_benchmark_results.sh`)
+   - Converts the result lines into the JSON format expected by the benchmark action
+
+## Benchmarks
+
+All benchmarks are run on a chest of a given dimension, where `size` is either the chest dimension
+(for structure benchmarks) or the resulting inventory slot count (for inventory and container benchmarks).
+Every benchmark runs one warmup iteration followed by three measured iterations, and reports the mean.
+
+| Benchmark | Description |
+|-----------|-------------|
+| `formation_<material>` | Building up a chest block by block, dominated by the multiblock detection that runs on every block placement |
+| `formation_<material>_interfaces` | Idem, but with every wall block being an interface block |
+| `revalidation_<material>` | Breaking and replacing a single wall block of a formed chest, which invalidates and revalidates the structure and its inventory |
+| `inventory_construction_<material>` | Constructing the backing inventory of a chest, as happens on (in)validation and on chunk load |
+| `inventory_memory_<material>` | Heap usage of that inventory, in bytes per slot |
+| `container_open_<material>` | Constructing the container for a chest, as happens when a player opens it |
+| `container_broadcast_<material>` | Synchronizing a single changed slot to the client, as happens on every tick in which the inventory changed |
+| `container_quickmove_<material>` | Shift-clicking an item into a full chest |
+| `client_inventory_fill_<material>` | Filling the client-side inventory copy, as happens when all contents are received |
+
+## Metrics
+
+- **Average Operation Time (ms)**: The average wall-clock time of a single operation.
+- **Bytes Per Slot**: The heap usage of a chest inventory, divided by its slot count.
+  This is a coarse measurement based on `Runtime`, so it is only meaningful in orders of magnitude.
+
+## Running locally
+
+```bash
+PERFORMANCE_BENCHMARK_ENABLED=true ./gradlew :loader-neoforge:runGameTestServer
+```
+
+Results are appended to `logs/benchmark_results.txt` inside the run directory,
+or to `$PERFORMANCE_BENCHMARK_OUTPUT` when that variable is set:
+
+```bash
+PERFORMANCE_BENCHMARK_ENABLED=true \
+  PERFORMANCE_BENCHMARK_OUTPUT=$PWD/benchmark_results.txt \
+  ./gradlew :loader-neoforge:runGameTestServer
+```
+
+The benchmarks are registered for all loaders, so they can also be run
+via `:loader-fabric:runGameTestServer` or `:loader-forge:runGameTestServer`.
+Note that the result file is appended to, so remove it between runs when comparing.
+
+## Result format
+
+```
+preset=formation_wood size=9 avgOperationTime=1234.567890
+preset=inventory_memory_netherite size=98415 bytesPerSlot=56
+```
+
+Which is converted into:
+
+```json
+[
+  {
+    "name": "CHEST LOAD: formation_wood_size_9",
+    "unit": "operation time (ms)",
+    "value": 1234.567890
+  },
+  {
+    "name": "CHEST MEMORY: inventory_memory_netherite_size_98415",
+    "unit": "bytes per slot",
+    "value": 56
+  }
+]
+```
+
+## Benchmark tracking
+
+The `benchmark-action/github-action-benchmark` GitHub action automatically:
+- Stores benchmark results in the `cyclops-performance-results` repository
+- Generates historical performance charts
+- Alerts when performance degrades beyond the configured threshold
+- Creates comments on commits
+
+## Adding new benchmarks
+
+1. Add a new `@GameTest` method in `GameTestsPerformance`
+2. Guard it with `isEnabled()`, and report results via `report(...)`
+3. The workflow will automatically execute and track the new benchmark

--- a/loader-common/src/main/java/org/cyclops/colossalchests/gametest/GameTestsPerformance.java
+++ b/loader-common/src/main/java/org/cyclops/colossalchests/gametest/GameTestsPerformance.java
@@ -1,0 +1,545 @@
+package org.cyclops.colossalchests.gametest;
+
+import com.google.common.collect.Sets;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import org.cyclops.colossalchests.Reference;
+import org.cyclops.colossalchests.block.ChestMaterial;
+import org.cyclops.colossalchests.block.ColossalChestConfig;
+import org.cyclops.colossalchests.blockentity.BlockEntityColossalChest;
+import org.cyclops.colossalchests.inventory.container.ContainerColossalChest;
+import org.cyclops.cyclopscore.inventory.LargeInventoryCommon;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Performance benchmarks for colossal chests.
+ *
+ * These are skipped unless the {@code PERFORMANCE_BENCHMARK_ENABLED} environment variable is set to {@code true},
+ * as they are significantly slower than regular game tests.
+ * See PERFORMANCE_BENCHMARKING.md for details.
+ *
+ * @author rubensworks
+ */
+public class GameTestsPerformance {
+
+    public static final String TEMPLATE_EMPTY = Reference.MOD_ID + ":empty10";
+    public static final BlockPos POS = BlockPos.ZERO.offset(1, 0, 1);
+
+    /**
+     * The default file that benchmark results are appended to, relative to the run directory.
+     */
+    public static final String DEFAULT_OUTPUT_FILE = "logs/benchmark_results.txt";
+
+    private static final int WARMUP_ITERATIONS = 1;
+    private static final int MEASURE_ITERATIONS = 3;
+
+    protected static boolean isEnabled() {
+        return "true".equalsIgnoreCase(System.getenv("PERFORMANCE_BENCHMARK_ENABLED"));
+    }
+
+    protected static void report(String preset, int size, double averageMillis) {
+        report(String.format(Locale.ROOT, "preset=%s size=%d avgOperationTime=%.6f", preset, size, averageMillis));
+    }
+
+    protected static void reportBytes(String preset, int size, long bytesPerSlot) {
+        report(String.format(Locale.ROOT, "preset=%s size=%d bytesPerSlot=%d", preset, size, bytesPerSlot));
+    }
+
+    protected static void report(String line) {
+        System.out.println("[BENCHMARK] " + line);
+        String output = System.getenv("PERFORMANCE_BENCHMARK_OUTPUT");
+        Path path = Paths.get(output == null ? DEFAULT_OUTPUT_FILE : output);
+        try {
+            if (path.getParent() != null) {
+                Files.createDirectories(path.getParent());
+            }
+            Files.write(path, (line + "\n").getBytes(StandardCharsets.UTF_8),
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not write benchmark results to " + path, e);
+        }
+    }
+
+    // --------------------------------------------------------------------
+    // Structure detection
+    // --------------------------------------------------------------------
+
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void benchmarkFormationWood5(GameTestHelper helper) {
+        benchmarkFormation(helper, ChestMaterial.WOOD, 5, false);
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void benchmarkFormationWood9(GameTestHelper helper) {
+        benchmarkFormation(helper, ChestMaterial.WOOD, 9, false);
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void benchmarkFormationWood9Interfaces(GameTestHelper helper) {
+        benchmarkFormation(helper, ChestMaterial.WOOD, 9, true);
+    }
+
+    /**
+     * Measure how long it takes to build up a chest of the given dimension, block by block.
+     * This is dominated by the multiblock detection that runs on every block placement.
+     */
+    protected void benchmarkFormation(GameTestHelper helper, ChestMaterial material, int dimension, boolean interfaces) {
+        if (!isEnabled()) {
+            helper.succeed();
+            return;
+        }
+
+        Set<BlockPos> interfacePositions = interfaces ? surfacePositions(POS, dimension) : Sets.newHashSet();
+
+        for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+            createChest(helper, dimension, material, interfacePositions);
+            clearChest(helper, dimension);
+        }
+
+        long total = 0;
+        for (int i = 0; i < MEASURE_ITERATIONS; i++) {
+            long start = System.nanoTime();
+            createChest(helper, dimension, material, interfacePositions);
+            total += System.nanoTime() - start;
+            clearChest(helper, dimension);
+        }
+
+        report("formation_" + material.getName() + (interfaces ? "_interfaces" : ""),
+                dimension, millis(total) / MEASURE_ITERATIONS);
+        helper.succeed();
+    }
+
+    /**
+     * Measure how long it takes to break and replace a single wall block of a formed chest.
+     * This invalidates and revalidates the whole structure, including its inventory.
+     */
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void benchmarkRevalidationWood9(GameTestHelper helper) {
+        benchmarkRevalidation(helper, ChestMaterial.WOOD, 9);
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void benchmarkRevalidationNetherite9(GameTestHelper helper) {
+        benchmarkRevalidation(helper, ChestMaterial.NETHERITE, 9);
+    }
+
+    protected void benchmarkRevalidation(GameTestHelper helper, ChestMaterial material, int dimension) {
+        if (!isEnabled()) {
+            helper.succeed();
+            return;
+        }
+
+        createChest(helper, dimension, material, Sets.newHashSet());
+        BlockPos wall = POS.offset(1, 0, 0);
+
+        for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+            destroyBlock(helper, wall);
+            helper.setBlock(wall, material.getBlockWall());
+        }
+
+        long total = 0;
+        for (int i = 0; i < MEASURE_ITERATIONS; i++) {
+            long start = System.nanoTime();
+            destroyBlock(helper, wall);
+            helper.setBlock(wall, material.getBlockWall());
+            total += System.nanoTime() - start;
+        }
+
+        clearChest(helper, dimension);
+        report("revalidation_" + material.getName(), dimension, millis(total) / MEASURE_ITERATIONS);
+        helper.succeed();
+    }
+
+    // --------------------------------------------------------------------
+    // Inventory
+    // --------------------------------------------------------------------
+
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void benchmarkInventoryConstructionWood9(GameTestHelper helper) {
+        benchmarkInventoryConstruction(helper, ChestMaterial.WOOD, 9);
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void benchmarkInventoryConstructionNetherite9(GameTestHelper helper) {
+        benchmarkInventoryConstruction(helper, ChestMaterial.NETHERITE, 9);
+    }
+
+    /**
+     * Measure how long it takes to (re)construct the backing inventory of a chest,
+     * as happens on structure (in)validation and on chunk load.
+     */
+    protected void benchmarkInventoryConstruction(GameTestHelper helper, ChestMaterial material, int dimension) {
+        if (!isEnabled()) {
+            helper.succeed();
+            return;
+        }
+
+        BlockEntityColossalChest chest = createChest(helper, dimension, material, Sets.newHashSet());
+        int size = chest.getInventory().getContainerSize();
+
+        for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+            chest.setSize(chest.getSize());
+        }
+
+        long total = 0;
+        for (int i = 0; i < MEASURE_ITERATIONS; i++) {
+            long start = System.nanoTime();
+            chest.setSize(chest.getSize());
+            total += System.nanoTime() - start;
+        }
+        report("inventory_construction_" + material.getName(), size, millis(total) / MEASURE_ITERATIONS);
+
+        reportBytes("inventory_memory_" + material.getName(), size, measureInventoryBytesPerSlot(chest, size));
+
+        clearChest(helper, dimension);
+        helper.succeed();
+    }
+
+    protected long measureInventoryBytesPerSlot(BlockEntityColossalChest chest, int size) {
+        Runtime runtime = Runtime.getRuntime();
+        chest.setInventory(null);
+        long before = usedMemory(runtime);
+        chest.setSize(chest.getSize());
+        long after = usedMemory(runtime);
+        return Math.max(0, (after - before) / size);
+    }
+
+    protected long usedMemory(Runtime runtime) {
+        System.gc();
+        System.gc();
+        return runtime.totalMemory() - runtime.freeMemory();
+    }
+
+    // --------------------------------------------------------------------
+    // Container
+    // --------------------------------------------------------------------
+
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void benchmarkContainerWood9(GameTestHelper helper) {
+        benchmarkContainer(helper, ChestMaterial.WOOD, 9);
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void benchmarkContainerNetherite9(GameTestHelper helper) {
+        benchmarkContainer(helper, ChestMaterial.NETHERITE, 9);
+    }
+
+    /**
+     * Measure the container operations that happen while a player has a chest opened:
+     * opening it, synchronizing changes on every tick, and shift-clicking an item into it.
+     */
+    protected void benchmarkContainer(GameTestHelper helper, ChestMaterial material, int dimension) {
+        if (!isEnabled()) {
+            helper.succeed();
+            return;
+        }
+
+        BlockEntityColossalChest chest = createChest(helper, dimension, material, Sets.newHashSet());
+        Player player = helper.makeMockPlayer(GameType.SURVIVAL);
+        int size = chest.getInventory().getContainerSize();
+
+        // Container opening
+        long total = 0;
+        for (int i = 0; i < WARMUP_ITERATIONS + MEASURE_ITERATIONS; i++) {
+            long start = System.nanoTime();
+            ContainerColossalChest container = new ContainerColossalChest(i, player.getInventory(), chest.getInventory());
+            long elapsed = System.nanoTime() - start;
+            container.removed(player);
+            if (i >= WARMUP_ITERATIONS) {
+                total += elapsed;
+            }
+        }
+        report("container_open_" + material.getName(), size, millis(total) / MEASURE_ITERATIONS);
+
+        // Change synchronization, as performed on every tick in which the inventory changed
+        ContainerColossalChest container = new ContainerColossalChest(0, player.getInventory(), chest.getInventory());
+        container.broadcastChanges();
+        total = 0;
+        for (int i = 0; i < WARMUP_ITERATIONS + MEASURE_ITERATIONS; i++) {
+            chest.getInventory().setItem(0, new ItemStack(Items.APPLE, i + 1));
+            long start = System.nanoTime();
+            container.broadcastChanges();
+            long elapsed = System.nanoTime() - start;
+            if (i >= WARMUP_ITERATIONS) {
+                total += elapsed;
+            }
+        }
+        report("container_broadcast_" + material.getName(), size, millis(total) / MEASURE_ITERATIONS);
+        chest.getInventory().setItem(0, ItemStack.EMPTY);
+
+        // Shift-clicking an item into a full chest, which has to scan for a target slot
+        for (int slot = 0; slot < size; slot++) {
+            chest.getInventory().setItem(slot, new ItemStack(Items.STONE, 64));
+        }
+        int playerSlotIndex = playerSlotIndex(container, size);
+        total = 0;
+        for (int i = 0; i < WARMUP_ITERATIONS + MEASURE_ITERATIONS; i++) {
+            container.getSlot(playerSlotIndex).set(new ItemStack(Items.APPLE));
+            long start = System.nanoTime();
+            container.quickMoveStack(player, playerSlotIndex);
+            long elapsed = System.nanoTime() - start;
+            if (i >= WARMUP_ITERATIONS) {
+                total += elapsed;
+            }
+        }
+        report("container_quickmove_" + material.getName(), size, millis(total) / MEASURE_ITERATIONS);
+
+        container.removed(player);
+        chest.getInventory().clearContent();
+        clearChest(helper, dimension);
+        helper.succeed();
+    }
+
+    protected int playerSlotIndex(ContainerColossalChest container, int chestSize) {
+        for (int i = chestSize; i < container.slots.size(); i++) {
+            Slot slot = container.getSlot(i);
+            if (slot.getItem().isEmpty()) {
+                return i;
+            }
+        }
+        throw new IllegalStateException("No empty player inventory slot available");
+    }
+
+    /**
+     * Measure the payload that is sent to a player when a chest is opened, for both an empty and a full chest.
+     *
+     * This mirrors the encoding that {@link ContainerColossalChest#updateCraftingInventory} performs,
+     * without actually sending anything, as a game test has no real client connection.
+     */
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void benchmarkContainerSyncWood9(GameTestHelper helper) {
+        if (!isEnabled()) {
+            helper.succeed();
+            return;
+        }
+
+        BlockEntityColossalChest chest = createChest(helper, 9, ChestMaterial.WOOD, Sets.newHashSet());
+        Player player = helper.makeMockPlayer(GameType.SURVIVAL);
+        HolderLookup.Provider provider = helper.getLevel().registryAccess();
+        int size = chest.getInventory().getContainerSize();
+        ContainerColossalChest container = new ContainerColossalChest(0, player.getInventory(), chest.getInventory());
+
+        measureSync(container, provider, "container_sync_empty_wood", size);
+
+        for (int slot = 0; slot < size; slot++) {
+            chest.getInventory().setItem(slot, new ItemStack(Items.STONE, 64));
+        }
+        measureSync(container, provider, "container_sync_full_wood", size);
+
+        container.removed(player);
+        chest.getInventory().clearContent();
+        clearChest(helper, 9);
+        helper.succeed();
+    }
+
+    protected void measureSync(ContainerColossalChest container, HolderLookup.Provider provider, String preset, int size) {
+        long total = 0;
+        long bytes = 0;
+        for (int i = 0; i < WARMUP_ITERATIONS + MEASURE_ITERATIONS; i++) {
+            long start = System.nanoTime();
+            bytes = encodeContents(container, provider);
+            long elapsed = System.nanoTime() - start;
+            if (i >= WARMUP_ITERATIONS) {
+                total += elapsed;
+            }
+        }
+        report(preset, size, millis(total) / MEASURE_ITERATIONS);
+        reportBytes(preset, size, bytes / size);
+    }
+
+    protected long encodeContents(ContainerColossalChest container, HolderLookup.Provider provider) {
+        CompoundTag buffer = new CompoundTag();
+        ListTag list = new ListTag();
+        buffer.put("stacks", list);
+        int i = 0;
+        for (ItemStack itemStack : container.getItems()) {
+            CompoundTag tag = new CompoundTag();
+            tag.putInt("slot", i++);
+            tag.put("stack", ItemStack.OPTIONAL_CODEC
+                    .encodeStart(provider.createSerializationContext(NbtOps.INSTANCE), itemStack)
+                    .getOrThrow());
+            list.add(tag);
+        }
+        CountingOutputStream counter = new CountingOutputStream();
+        try {
+            NbtIo.write(buffer, new DataOutputStream(counter));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return counter.getCount();
+    }
+
+    /**
+     * Measure the container operations for the largest chest that can be built with the default configuration:
+     * a 20x20x20 netherite chest. Its structure does not fit inside a game test template,
+     * so the inventory is created directly.
+     */
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void benchmarkContainerMaxSize(GameTestHelper helper) {
+        if (!isEnabled()) {
+            helper.succeed();
+            return;
+        }
+
+        int size = chestSize(ColossalChestConfig.maxSize, ChestMaterial.NETHERITE);
+        Player player = helper.makeMockPlayer(GameType.SURVIVAL);
+
+        long start = System.nanoTime();
+        LargeInventoryCommon inventory = new LargeInventoryCommon(size, 64);
+        ContainerColossalChest container = new ContainerColossalChest(0, player.getInventory(), inventory);
+        report("container_open_maxsize", size, millis(System.nanoTime() - start));
+
+        inventory.setItem(0, new ItemStack(Items.APPLE));
+        container.broadcastChanges();
+        inventory.setItem(0, new ItemStack(Items.APPLE, 2));
+        start = System.nanoTime();
+        container.broadcastChanges();
+        report("container_broadcast_maxsize", size, millis(System.nanoTime() - start));
+
+        for (int slot = 0; slot < size; slot++) {
+            inventory.setItem(slot, new ItemStack(Items.STONE, 64));
+        }
+        int playerSlotIndex = playerSlotIndex(container, size);
+        container.getSlot(playerSlotIndex).set(new ItemStack(Items.APPLE));
+        start = System.nanoTime();
+        container.quickMoveStack(player, playerSlotIndex);
+        report("container_quickmove_maxsize", size, millis(System.nanoTime() - start));
+
+        container.removed(player);
+        helper.succeed();
+    }
+
+    /**
+     * An output stream that only counts the bytes written to it.
+     */
+    protected static class CountingOutputStream extends OutputStream {
+        private long count = 0;
+
+        @Override
+        public void write(int b) {
+            this.count++;
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) {
+            this.count += len;
+        }
+
+        public long getCount() {
+            return count;
+        }
+    }
+
+    /**
+     * Measure the client-side cost of receiving all chest contents when a chest is opened.
+     */
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void benchmarkClientInventoryWood9(GameTestHelper helper) {
+        if (!isEnabled()) {
+            helper.succeed();
+            return;
+        }
+
+        int size = chestSize(9, ChestMaterial.WOOD);
+        long total = 0;
+        for (int i = 0; i < WARMUP_ITERATIONS + MEASURE_ITERATIONS; i++) {
+            long start = System.nanoTime();
+            LargeInventoryCommon inventory = new LargeInventoryCommon(size, 64);
+            for (int slot = 0; slot < size; slot++) {
+                inventory.setItem(slot, new ItemStack(Items.STONE, 64));
+            }
+            long elapsed = System.nanoTime() - start;
+            if (i >= WARMUP_ITERATIONS) {
+                total += elapsed;
+            }
+        }
+        report("client_inventory_fill_wood", size, millis(total) / MEASURE_ITERATIONS);
+        helper.succeed();
+    }
+
+    // --------------------------------------------------------------------
+    // Helpers
+    // --------------------------------------------------------------------
+
+    protected static double millis(long nanos) {
+        return nanos / 1_000_000D;
+    }
+
+    protected int chestSize(int dimension, ChestMaterial material) {
+        return (int) Math.ceil((Math.pow(dimension, 3) * 27) * material.getInventoryMultiplier() / 9) * 9;
+    }
+
+    protected Set<BlockPos> surfacePositions(BlockPos pos, int dimension) {
+        Set<BlockPos> positions = Sets.newHashSet();
+        for (int x = 0; x < dimension; x++) {
+            for (int y = 0; y < dimension; y++) {
+                for (int z = 0; z < dimension; z++) {
+                    if ((x == 0 && y == 0 && z == 0)) {
+                        continue; // Core
+                    }
+                    if (x == 0 || y == 0 || z == 0 || x == dimension - 1 || y == dimension - 1 || z == dimension - 1) {
+                        positions.add(pos.offset(x, y, z));
+                    }
+                }
+            }
+        }
+        return positions;
+    }
+
+    protected BlockEntityColossalChest createChest(GameTestHelper helper, int dimension, ChestMaterial material, Set<BlockPos> interfaces) {
+        for (int x = 0; x < dimension; x++) {
+            for (int y = 0; y < dimension; y++) {
+                for (int z = 0; z < dimension; z++) {
+                    BlockPos poso = POS.offset(x, y, z);
+                    if (x == 0 && y == 0 && z == 0) {
+                        helper.setBlock(poso, material.getBlockCore());
+                    } else if (x == 0 || y == 0 || z == 0 || x == dimension - 1 || y == dimension - 1 || z == dimension - 1) {
+                        helper.setBlock(poso, interfaces.contains(poso) ? material.getBlockInterface() : material.getBlockWall());
+                    }
+                }
+            }
+        }
+        return helper.getBlockEntity(POS);
+    }
+
+    protected void destroyBlock(GameTestHelper helper, BlockPos pos) {
+        BlockState blockState = helper.getBlockState(pos);
+        if (helper.getLevel().removeBlock(helper.absolutePos(pos), false)) {
+            blockState.getBlock().destroy(helper.getLevel(), helper.absolutePos(pos), blockState);
+        }
+    }
+
+    protected void clearChest(GameTestHelper helper, int dimension) {
+        for (int x = 0; x < dimension; x++) {
+            for (int y = 0; y < dimension; y++) {
+                for (int z = 0; z < dimension; z++) {
+                    helper.setBlock(POS.offset(x, y, z), Blocks.AIR);
+                }
+            }
+        }
+    }
+
+}

--- a/loader-fabric/src/main/resources/fabric.mod.json
+++ b/loader-fabric/src/main/resources/fabric.mod.json
@@ -23,6 +23,7 @@
     ],
     "fabric-gametest": [
       "org.cyclops.colossalchests.gametest.GameTestsCommon",
+      "org.cyclops.colossalchests.gametest.GameTestsPerformance",
       "org.cyclops.colossalchests.gametest.GameTestsFabric"
     ]
   },

--- a/loader-forge/src/main/java/org/cyclops/colossalchests/gametest/GameTestsLoaderForge.java
+++ b/loader-forge/src/main/java/org/cyclops/colossalchests/gametest/GameTestsLoaderForge.java
@@ -16,7 +16,8 @@ public class GameTestsLoaderForge extends GameTestsCommon {
     @GameTestGenerator
     public Collection<TestFunction> generateCommonTests() throws InstantiationException, IllegalAccessException {
         return GameTestLoaderHelpers.generateCommonTests(Reference.MOD_ID, new Class[]{
-                GameTestsCommon.class
+                GameTestsCommon.class,
+                GameTestsPerformance.class
         });
     }
 }

--- a/loader-neoforge/src/main/java/org/cyclops/colossalchests/gametest/GameTestsLoaderNeoForge.java
+++ b/loader-neoforge/src/main/java/org/cyclops/colossalchests/gametest/GameTestsLoaderNeoForge.java
@@ -16,7 +16,8 @@ public class GameTestsLoaderNeoForge extends GameTestsCommon {
     @GameTestGenerator
     public Collection<TestFunction> generateCommonTests() throws InstantiationException, IllegalAccessException {
         return GameTestLoaderHelpers.generateCommonTests(Reference.MOD_ID, new Class[]{
-                GameTestsCommon.class
+                GameTestsCommon.class,
+                GameTestsPerformance.class
         });
     }
 }


### PR DESCRIPTION
Adds continuous performance benchmarking, mirroring the setup in [Integrated Dynamics](https://github.com/CyclopsMC/IntegratedDynamics/blob/master-26-lts/PERFORMANCE_BENCHMARKING.md).

Colossal chest costs scale with the slot count (up to 1,080,000 for a 20³ netherite chest) and with the structure volume (up to 8,000 positions), so these benchmarks cover the operations that scale with either.

### What is added

- `GameTestsPerformance` (`loader-common`), registered for all three loaders, benchmarking:
  - structure formation block by block, with and without an all-interface surface
  - breaking and replacing a single wall block (structure invalidation + revalidation)
  - inventory construction time, and its heap usage in bytes per slot
  - container opening, per-tick change synchronization, and shift-clicking
  - the payload sent to a player when a chest is opened, for an empty and a full chest
  - the same container operations at the largest configurable chest size
- `.github/workflows/performance.yml` and `.github/parse_benchmark_results.sh` to track results over time via `benchmark-action/github-action-benchmark`
- `PERFORMANCE_BENCHMARKING.md` documenting how to run and extend them

### Behaviour

The benchmarks are skipped unless `PERFORMANCE_BENCHMARK_ENABLED=true`, so regular `runGameTestServer` runs are unaffected. Results are appended to `logs/benchmark_results.txt` in the run directory, or to `$PERFORMANCE_BENCHMARK_OUTPUT`.

```bash
PERFORMANCE_BENCHMARK_ENABLED=true \
  PERFORMANCE_BENCHMARK_OUTPUT=$PWD/benchmark_results.txt \
  ./gradlew :loader-neoforge:runGameTestServer
```

### Validation

- `./gradlew build` passes.
- `./gradlew :loader-neoforge:runGameTestServer` passes (all 106 required tests) with the benchmarks disabled.
- With the benchmarks enabled, all of them run and report. Some current figures from a dev environment:

```
preset=container_open_maxsize      size=1080000 avgOperationTime=159.607624
preset=container_quickmove_maxsize size=1080000 avgOperationTime=439.018073
preset=container_broadcast_maxsize size=1080000 avgOperationTime=15.914556
preset=container_sync_empty_wood   size=19683   avgOperationTime=21.125706 (21 bytes/slot)
preset=formation_wood_interfaces   size=9       avgOperationTime=91.900687
```

Note that the workflow needs the `PAT` secret to push to `cyclops-performance-results`, like the Integrated Dynamics workflow does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ParaU4Neoi7UaZ3xU8Rv6

---
_Generated by [Claude Code](https://claude.ai/code/session_019ParaU4Neoi7UaZ3xU8Rv6)_